### PR TITLE
Feature: Adding -excludeMethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ and calling all exported methods of a struct, or calling all exported methods of
 It is useful in cases where code wants to be aware of any newly added members.
 
 ## Install
+
 ```
 go get -u github.com/kisunji/typecover/cmd/typecover
 ```
@@ -13,27 +14,39 @@ go get -u github.com/kisunji/typecover/cmd/typecover
 ## Usage
 
 Using the CLI
+
 ```
 typecover [package/file]
 ```
 
 Comment directives
+
 ```
 # Local Type
 // typecover:TypeName
 
 # Imported Type
-// typecover:pkg.TypeName 
+// typecover:pkg.TypeName
 
 # Excluding members
 // typecover:TypeName -exclude Field3,Field4,Field5
+
+# Excluding all methods (struct or interface)
+// typecover:TypeName -excludeMethods
+
+# Excluding specific members and all methods
+// typecover:TypeName -exclude Field3,Field4 -excludeMethods
 ```
+
 `typecover:YourType` will check for the existence of all exported members of `YourType` in the comment's associated code
 block (for details on how comments are associated with code, see [here](https://golang.org/pkg/go/ast/#NewCommentMap)).
+
+If the `-excludeMethods` flag is present, all exported methods of the target type (or interface methods) are ignored for the purposes of coverage. This can be combined with `-exclude` to ignore certain fields while also ignoring all methods.
 
 ## Examples
 
 ### Struct assignment
+
 ```go
 type MyStruct struct {
 	MyField1 string
@@ -42,41 +55,48 @@ type MyStruct struct {
 }
 
 // typecover:MyStruct
-m := MyStruct{ 
+m := MyStruct{
     MyField1: "hello",
 }
 ```
+
 ```
 Type example.MyStruct is missing MyField2
 ```
 
 ### Covering a code block
+
 The `typecover` annotation can be placed at a higher level (func, if-stmt, for-loop) to cover the whole block.
+
 ```go
 // typecover:MyStruct
 func example() {
     m := MyStruct{}
-    m.MyField2 = "world"    
+    m.MyField2 = "world"
 }
 ```
+
 ```
 Type example.MyStruct is missing MyField1
 ```
 
 ### Using imported types
+
 ```go
 // typecover:flag.Flag
-f := flag.Flag{ 
+f := flag.Flag{
     Name:  "test",
     Usage: "usage instructions",
     Value: nil,
 }
 ```
+
 ```
 Type flag.Flag is missing DefValue
 ```
 
 ### Copying fields from exported type
+
 ```go
 //typecover:flag.Flag
 func cloneFlag(f flag.Flag) MyFlag {
@@ -87,11 +107,13 @@ func cloneFlag(f flag.Flag) MyFlag {
     }
 }
 ```
+
 ```
 Type flag.Flag is missing DefValue
 ```
 
 ### Enforcing all methods in a Builder interface
+
 ```go
 type ExampleBuilder interface {
 	Option1() ExampleBuilder
@@ -105,11 +127,13 @@ func MakeExample() Example {
 	return b.Build()
 }
 ```
+
 ```
 Type example.ExampleBuilder is missing Option1
 ```
 
 ### Exclude a member from being checked
+
 ```go
 type ExampleBuilder interface {
 	Option1() ExampleBuilder
@@ -123,6 +147,7 @@ func MakeExample() Example {
 	return b.Build()
 }
 ```
+
 ```
 (passes!)
 ```
@@ -132,3 +157,4 @@ func MakeExample() Example {
 https://github.com/mbilski/exhaustivestruct
 
 https://github.com/reillywatson/enumcover
+

--- a/testdata/src/interfaces/excludemethods.go
+++ b/testdata/src/interfaces/excludemethods.go
@@ -1,0 +1,11 @@
+package interfaces
+
+// typecover:MyInterface -excludeMethods
+func excludeMethodsPass() {
+	_ = &myStruct{}
+}
+
+// typecover:MyInterface -excludeMethods -exclude MyFunc1
+func excludeMethodsWithExcludePass() {
+	_ = &myStruct{}
+}

--- a/testdata/src/structs/excludemethods.go
+++ b/testdata/src/structs/excludemethods.go
@@ -1,0 +1,19 @@
+package structs
+
+// typecover:MyStruct -excludeMethods
+func testBlockWithExcludesMethodsPass() {
+	m := MyStruct{}
+	m.MyField1 = "cool"
+	m.MyField2 = "hello"
+	if true {
+		m.MyField3 = "world"
+	}
+}
+
+// typecover:MyStruct -excludeMethods -exclude MyField1, MyField2
+func testBlockWithExcludesMethodsAndExcludePass() {
+	m := MyStruct{}
+	if true {
+		m.MyField3 = "cool"
+	}
+}

--- a/typecover.go
+++ b/typecover.go
@@ -21,23 +21,36 @@ var Analyzer = &analysis.Analyzer{
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 }
 
-var commentRegex = regexp.MustCompile(`typecover:([\w.]+)`)
+var commentRegex = regexp.MustCompile(`typecover:\s*([\w.]+)`)
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	for _, file := range pass.Files {
 		commentMap := ast.NewCommentMap(pass.Fset, file, file.Comments)
 		ast.Inspect(file, func(n ast.Node) bool {
 			for _, comments := range commentMap[n] {
 				for _, comment := range comments.List {
-					var exclude []string
+					var (
+						exclude        []string
+						excludeMethods bool
+					)
+
 					matches := commentRegex.FindAllStringSubmatch(comment.Text, 1)
 					if len(matches) == 1 && len(matches[0]) == 2 {
-						// Check if there are any member to exclude
-						ss := strings.Split(comment.Text, "-exclude")
+						commentText := comment.Text
+
+						// Detect -excludeMethods flag (no arguments)
+						if strings.Contains(commentText, "-excludeMethods") {
+							excludeMethods = true
+							// Remove the flag so it does not interfere with -exclude parsing
+							commentText = strings.ReplaceAll(commentText, "-excludeMethods", "")
+						}
+
+						// Look for -exclude <list>
+						ss := strings.Split(commentText, "-exclude")
 						if len(ss) > 1 {
 							exclude = strings.Split(strings.TrimLeft(ss[1], "= "), ",")
 						}
-						if len(ss) > 2 {
+						if len(ss) > 2 { // More than one -exclude encountered
 							reportNodef(pass, n, "Detected more than one '~'. Separate arguments with commas")
 						}
 
@@ -47,7 +60,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 							reportNodef(pass, n, "Type %s not found in project scope", typeName)
 							return false
 						}
-						missing := checkMembers(pass, n, t, exclude)
+						missing := checkMembers(pass, n, t, exclude, excludeMethods)
 						if len(missing) > 0 {
 							reportNodef(pass, n, "Type %s is missing %s", typeName, strings.Join(missing, ", "))
 						}
@@ -60,16 +73,22 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
-func checkMembers(pass *analysis.Pass, n ast.Node, target types.Type, exclude []string) []string {
+// checkMembers determines which exported members (fields / methods) of the target type
+// are present in the covered AST node. It returns a slice of missing members.
+// If excludeMethods is true, exported methods are ignored (treated as satisfied).
+func checkMembers(pass *analysis.Pass, n ast.Node, target types.Type, exclude []string, excludeMethods bool) []string {
 	membersFound := map[string]bool{}
 
-	for _, t := range []types.Type{target, types.NewPointer(target)} {
-		mset := types.NewMethodSet(t)
-		for i := 0; i < mset.Len(); i++ {
-			switch u := mset.At(i).Obj().(type) {
-			case *types.Func:
-				if u.Exported() {
-					membersFound[u.Name()] = false
+	// Unless -excludeMethods is provided, gather method set for both the type and *type.
+	if !excludeMethods {
+		for _, t := range []types.Type{target, types.NewPointer(target)} {
+			mset := types.NewMethodSet(t)
+			for i := 0; i < mset.Len(); i++ {
+				switch u := mset.At(i).Obj().(type) {
+				case *types.Func:
+					if u.Exported() {
+						membersFound[u.Name()] = false
+					}
 				}
 			}
 		}
@@ -77,9 +96,11 @@ func checkMembers(pass *analysis.Pass, n ast.Node, target types.Type, exclude []
 
 	switch u := target.Underlying().(type) {
 	case *types.Interface:
-		for i := 0; i < u.NumMethods(); i++ {
-			if u.Method(i).Exported() {
-				membersFound[u.Method(i).Name()] = false
+		if !excludeMethods { // Only track interface methods when not excluded
+			for i := 0; i < u.NumMethods(); i++ {
+				if u.Method(i).Exported() {
+					membersFound[u.Method(i).Name()] = false
+				}
 			}
 		}
 
@@ -147,8 +168,12 @@ func checkMembers(pass *analysis.Pass, n ast.Node, target types.Type, exclude []
 
 	// Mark all excluded members as found.
 	for _, e := range exclude {
-		if _, ok := membersFound[strings.TrimSpace(e)]; ok {
-			membersFound[e] = true
+		trimmed := strings.TrimSpace(e)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := membersFound[trimmed]; ok {
+			membersFound[trimmed] = true
 		}
 	}
 


### PR DESCRIPTION
Adding the `-excludeMethods` flag to ignore methods from the coverage/analysis.

`// typecover:TypeName -excludeMethods`